### PR TITLE
Requirements fix (python 3.8)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ansi2html==1.5.2
 numpy==1.19.1
 opencv-python==4.4.0.42
-pkg-resources==0.0.0
+#pkg-resources==0.0.0
 six==1.15.0
 sty==1.0.0b12


### PR DESCRIPTION
I'm not sure what is the role of this pkg-resources package - so i've only commented it out for the time being, because it causes the problem in my env: 

```
(venv) ➜  Te-We git:(requirements) ✗ pip install -r requirements.txt 
...
ERROR: Could not find a version that satisfies the requirement pkg-resources==0.0.0 (from -r requirements.txt (line 4)) (from versions: none)
ERROR: No matching distribution found for pkg-resources==0.0.0 (from -r requirements.txt (line 4))

```

maybe there is something wrong with my environment, but without this package, i can install and run the app :)